### PR TITLE
Allow --add-location parameter

### DIFF
--- a/tasks/pot.js
+++ b/tasks/pot.js
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
 		language: false,
 		encoding: false,
 		text_domain: 'messages',
+		add_location: false,
 		package_version: pkg.version,
 		package_name: pkg.name,
 		msgid_bugs_address: false,
@@ -57,6 +58,9 @@ module.exports = function(grunt) {
 
 	//Set input files encoding, if required
 	var encoding = ( options.encoding ? " --from-code="+options.encoding : "" );
+	
+	// Set location format (default: full)
+	var add_location = ( options.add_location ? " --add-location="+options.add_location : "" );
 
 	//Generate header
 	if( options.package_version ){
@@ -92,7 +96,7 @@ module.exports = function(grunt) {
 
 	//Compile and run command
 	var exec = require('child_process').exec;
-	var command = 'xgettext' + join + ' --default-domain=' + options.text_domain + ' -o '+potFile + language + encoding + keywords + headerOptions + inputFiles;
+	var command = 'xgettext' + join + ' --default-domain=' + options.text_domain + ' -o '+potFile + language + encoding + keywords + add_location + headerOptions + inputFiles;
 	var done = grunt.task.current.async(); 
 	
 	grunt.verbose.writeln('Executing: ' + command);


### PR DESCRIPTION
Allow usage of the --add-location parameter. By default, the location
consists of a hash, colon, file name and line number. In more recent
versions of xgettext, this can be altered to 'none' or 'file'. The
default value is 'full', but this is implied when the parameter is
missing.

I want to remove the line numbers from the .pot-file, because they
change frequently and this causes differences in the .pot-file that are
not really changes, but do show op in the versioning system each time.